### PR TITLE
Change the incomplete last period's weight to 1

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -226,7 +226,7 @@ function find_period_weights(
     incomplete_period_weight = nothing
   else
     complete_period_weight = 1.0
-    incomplete_period_weight = last_period_duration / period_duration
+    incomplete_period_weight = 1.0
   end
   return complete_period_weight, incomplete_period_weight
 end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -122,7 +122,7 @@ end
       clustering_result =
         find_representative_periods(clustering_data, 2; method = :k_means, init = :kmcen)
 
-      clustering_result.weight_matrix == [1.0 0.0; 0.0 0.5]
+      clustering_result.weight_matrix == [1.0 0.0; 0.0 1.0]
     end
 
     @test begin
@@ -172,7 +172,7 @@ end
       clustering_result =
         find_representative_periods(clustering_data, 2; method = :k_medoids, init = :kmcen)
 
-      clustering_result.weight_matrix == [1.0 0.0; 0.0 0.5]
+      clustering_result.weight_matrix == [1.0 0.0; 0.0 1.0]
     end
 
     @test begin

--- a/test/test-weight-fitting.jl
+++ b/test/test-weight-fitting.jl
@@ -49,7 +49,7 @@ end
         init = :kmcen,
       )
       TulipaClustering.fit_rep_period_weights!(clustering_result; weight_type = :convex, niters = 5)
-      sum(clustering_result.weight_matrix) ≈ 365 / 7 &&
+      sum(clustering_result.weight_matrix) ≈ round(365 / 7, RoundUp) &&
         all(sum(clustering_result.weight_matrix[1:(end - 1), :], dims = 2) .≈ 1.0)
     end
   end


### PR DESCRIPTION
If the last period is incomplete and it has a dedicated representative, this representative's weight should be 1. In the old version it was last_period_duration/period_duration, but this is not necessary, because of how it is actually incorporated into TulipaEnergyModel.jl