### PR TITLE
Add a progress bar to weight fitting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/src/TulipaClustering.jl
+++ b/src/TulipaClustering.jl
@@ -6,6 +6,7 @@ using DataFrames
 using Distances
 using Clustering
 using SparseArrays
+using ProgressBars
 
 include("input-tables.jl")
 include("structures.jl")

--- a/src/weight_fitting.jl
+++ b/src/weight_fitting.jl
@@ -152,6 +152,7 @@ The arguments:
         weight bounded from above by one.
   - `tol`: algorithm's tolerance; when the weights are adjusted by a value less
     then or equal to `tol`, they stop being fitted further.
+  - `show_progress`: if `true`, a progress bar will be displayed.
   - other arguments control the projected subgradient method; they are passed
     through to `TulipaClustering.projected_subgradient_descent!`.
 """
@@ -161,6 +162,7 @@ function fit_rep_period_weights!(
   rp_matrix::Matrix{Float64};
   weight_type::Symbol = :dirac,
   tol::Float64 = 10e-3,
+  show_progress = false,
   args...,
 )
   # Determine the appropriate projection method
@@ -185,7 +187,15 @@ function fit_rep_period_weights!(
 
   is_sparse = issparse(weight_matrix)
 
-  for period ∈ 1:n_periods  # TODO: this can be parallelized; investigate
+  if show_progress
+    println("Fitting representative period weights:")
+    periods = ProgressBar(1:n_periods)
+  else
+    periods = 1:n_periods
+  end
+
+  for period ∈ periods
+    # TODO: this can be parallelized; investigate
     target_vector = clustering_matrix[:, period]
     subgradient = (x) -> rp_matrix' * (rp_matrix * x - target_vector)
     x = Vector(weight_matrix[period, 1:n_rp])

--- a/test/test-weight-fitting.jl
+++ b/test/test-weight-fitting.jl
@@ -74,6 +74,27 @@ end
       )
       all(sum(clustering_result.weight_matrix[1:(end - 1), :], dims = 2) .≤ 1.0)
     end
+
+    @test begin
+      dir = joinpath(INPUT_FOLDER, "EU")
+      clustering_data = TulipaClustering.read_clustering_data_from_csv_folder(dir)
+      split_into_periods!(clustering_data; period_duration = 24 * 7)
+      clustering_result = find_representative_periods(
+        clustering_data,
+        10;
+        drop_incomplete_last_period = false,
+        method = :k_means,
+        distance = SqEuclidean(),
+        init = :kmcen,
+      )
+      TulipaClustering.fit_rep_period_weights!(
+        clustering_result;
+        weight_type = :conical_bounded,
+        niters = 5,
+        show_progress = true,
+      )
+      all(sum(clustering_result.weight_matrix[1:(end - 1), :], dims = 2) .≤ 1.0)
+    end
   end
 
   @testset "Make sure that weight fitting works correctly for conical weights" begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Added an optional progress bar for the weight fitting method. This is useful when there are many periods to find weights for, as the method can take a while to run.

## List of related issues or pull requests

Closes #22 