### PR TITLE
Update abelsiqueira/COPIERTemplate.jl to JuliaBesties/BestieTemplate.jl

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,4 +9,4 @@ PackageName: TulipaClustering
 PackageOwner: TulipaEnergy
 PackageUUID: 314fac8b-c762-4aa3-9d12-851379729163
 _commit: v0.7.0
-_src_path: https://github.com/abelsiqueira/COPIERTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
