### PR TITLE
Add medoids information to the results

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -202,12 +202,14 @@ function find_auxiliary_data(clustering_data::AbstractDataFrame)
   period_duration = maximum(clustering_data.timestep)
   last_period_duration =
     maximum(clustering_data[clustering_data.period .== n_periods, :timestep])
+  medoids = nothing
 
   return AuxiliaryClusteringData(
     key_columns,
     period_duration,
     last_period_duration,
     n_periods,
+    medoids,
   )
 end
 
@@ -483,6 +485,7 @@ function find_representative_periods(
     # Reinterpret the results
     rp_matrix = clustering_matrix[:, kmedoids_result.medoids]
     assignments = kmedoids_result.assignments
+    aux.medoids = kmedoids_result.medoids
   else
     throw(ArgumentError("Clustering method is not supported"))
   end
@@ -507,6 +510,9 @@ function find_representative_periods(
       rp = n_rp,
       key_columns = aux.key_columns,
     )
+    if method ≡ :k_medoids
+      append!(aux.medoids, n_complete_periods + 1)
+    end
   end
 
   return ClusteringResult(rp_df, weight_matrix, clustering_matrix, rp_matrix, aux)

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -7,14 +7,16 @@ mutable struct AuxiliaryClusteringData
   period_duration::Int
   last_period_duration::Int
   n_periods::Int
+  medoids::Union{Vector{Int}, Nothing}
 
   function AuxiliaryClusteringData(
     key_columns,
     period_duration,
     last_period_duration,
     n_periods,
+    medoids,
   )
-    return new(key_columns, period_duration, last_period_duration, n_periods)
+    return new(key_columns, period_duration, last_period_duration, n_periods, medoids)
   end
 end
 

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -64,7 +64,7 @@ end
   end
 end
 
-@testset "Data valudation" begin
+@testset "Data validation" begin
   @testset "Make sure that when the columns are right validation works and the key columns are found" begin
     @test begin
       df =


### PR DESCRIPTION
The information on the medoids is necessary for the SpineOpt model to identify the value periods in the original data. These changes add that information to the auxiliary data structure only if the method is `k-medoids`. The default value in the structure is nothing.

## Related issues

Closes #55 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
