### PR TITLE
83 convex hull with null

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -599,7 +599,7 @@ function find_representative_periods(
     end
 
     # Add null to the clustering matrix
-    matrix = [clustering_matrix zeros(size(clustering_matrix, 1), 1)]
+    matrix = [zeros(size(clustering_matrix, 1), 1) clustering_matrix]
 
     # Do the clustering
     hull_indices =

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -213,6 +213,21 @@ end
   end
 end
 
+@testset "Convex hull with null clustering" begin
+  @testset "Make sure that the furthest point from 0 is found as first representative" begin
+    @test begin
+      clustering_data = DataFrame(; period = [1, 2], value = [1.0, 0.5], timestep = [1, 1])
+      clustering_result = find_representative_periods(
+        clustering_data,
+        1;
+        distance = SqEuclidean(),
+        method = :convex_hull_with_null,
+      )
+      clustering_result.profiles[!, :value] == [1.0]
+    end
+  end
+end
+
 @testset "Bad clustering method" begin
   @testset "Make sure that clustering fails when incorrect method is given" begin
     @test_throws ArgumentError begin


### PR DESCRIPTION
## Related issues

Closes #83 

Also fixes test cases not passing due to an error in reading of the profiles.csv file in the test cases. Fixed by removing the first line from profiles.csv.

## Added test case

The added test case tries to find a representative in the one dimensional space for points [1.0, 0.5] with `method = :convex_hull_with_null`. Initially, since the zero vector was added to the end of the clustering matrix the value 1.0 was not selected as first representative, while it should be since it is the furthest away from 0.0. Now, with the small fix, the test passes. 

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
