### PR TITLE
Add initial representatives before clustering

### DIFF
--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -751,6 +751,20 @@ function find_representative_periods(
         rp = n_rp,
         key_columns = aux.key_columns,
       )
+
+      # Since there is a probability that intial_representatives is not sorted in same way as clustering_matrix, need to sort first based on keys
+      # TODO: see if this is the most efficient approach
+      values_dict = Dict(
+        row[aux.key_columns] => row[:value] for
+        row in eachrow(initial_representatives[initial_representatives.period .== p, :])
+      )
+      values = [values_dict[key] for key in eachrow(keys)]
+
+      if p == 1 && isnothing(rp_matrix)
+        rp_matrix = reshape(values, :, 1)
+      else
+        rp_matrix = hcat(rp_matrix, values)
+      end
     end
   end
 

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -808,7 +808,7 @@ function validate_initial_representatives(
   # Calling find_auxiliary_data on the initial representatives already checks whether the dataframes satisfies some of the base requirements (:period, :value, :timestep)
   aux_initial = find_auxiliary_data(initial_representatives)
 
-  # Multiple checks to ensure that the initial representatives are compatible with the clustering data
+  # 1. Check that the column names for initial representatives are the same as for clustering data
   if aux_clustering.key_columns ≠ aux_initial.key_columns
     throw(
       ArgumentError(
@@ -817,6 +817,7 @@ function validate_initial_representatives(
     )
   end
 
+  # 2. Check that initial representatives do not contain a incomplete period
   if aux_initial.last_period_duration ≠ aux_initial.period_duration
     throw(
       ArgumentError(
@@ -825,6 +826,7 @@ function validate_initial_representatives(
     )
   end
 
+  # 3. Check that the initial representatives and clustering data have the same keys
   #TODO: see if this is the most efficient approach
   key_columns_initial = select(initial_representatives, aux_clustering.key_columns)
   key_columns_clustering = select(clustering_data, aux_clustering.key_columns)
@@ -843,6 +845,7 @@ function validate_initial_representatives(
     )
   end
 
+  # 4. Make sure that initial representatives does not contain more periods than asked
   if !last_period_excluded && n_rp < aux_initial.n_periods
     throw(
       ArgumentError(

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -1,4 +1,5 @@
-export find_representative_periods, split_into_periods!
+export find_representative_periods,
+  split_into_periods!, find_auxiliary_data, validate_initial_representatives
 
 """
     combine_periods!(df)
@@ -501,7 +502,7 @@ function find_representative_periods(
   drop_incomplete_last_period::Bool = false,
   method::Symbol = :k_means,
   distance::SemiMetric = SqEuclidean(),
-  initial_representatives::AbstractDataFrame,
+  initial_representatives::AbstractDataFrame = DataFrame(),
   args...,
 )
   # Check that the number of RPs makes sense. The first check can be done immediately,

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -812,7 +812,7 @@ function validate_initial_representatives(
   if aux_clustering.key_columns ≠ aux_initial.key_columns
     throw(
       ArgumentError(
-        "Initial representatives have different key columns than the clustering data",
+        "Key columns of initial represenatives do not match clustering data\nExpected was: $(aux_clustering.key_columns) \nFound was: $(aux_initial.key_columns)",
       ),
     )
   end
@@ -828,12 +828,18 @@ function validate_initial_representatives(
   #TODO: see if this is the most efficient approach
   key_columns_initial = select(initial_representatives, aux_clustering.key_columns)
   key_columns_clustering = select(clustering_data, aux_clustering.key_columns)
-  set_initial = Set(collect(eachrow(key_columns_initial)))
-  set_clustering = Set(collect(eachrow(key_columns_clustering)))
+  keys_initial = Set(collect(eachrow(key_columns_initial)))
+  keys_clustering = Set(collect(eachrow(key_columns_clustering)))
 
-  if set_initial ≠ set_clustering
+  if keys_initial ≠ keys_clustering
+    more_keys_initial = length(setdiff(keys_initial, keys_clustering))
+    more_keys_clustering = length(setdiff(keys_clustering, keys_initial))
     throw(
-      ArgumentError("Initial representatives have different keys than the clustering data"),
+      ArgumentError(
+        "Initial representatives and clustering data do not have the same keys\n" *
+        "There are $(more_keys_initial) extra keys in initial representatives\n" *
+        "and $(more_keys_clustering) extra keys in clustering data.",
+      ),
     )
   end
 

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -642,6 +642,7 @@ function find_representative_periods(
         h in hull_indices
       ]) for p in 1:n_complete_periods
     ]
+    clustering_matrix = clustering_matrix[:, (i_rp + 1):end]
     aux.medoids = hull_indices
   elseif method ≡ :convex_hull_with_null
     # Check if we can add null to the clustering matrix. The distance to null can
@@ -680,6 +681,7 @@ function find_representative_periods(
         h in hull_indices
       ]) for p in 1:n_complete_periods
     ]
+    clustering_matrix = clustering_matrix[:, (i_rp + 1):end]
 
     aux.medoids = hull_indices
   elseif method ≡ :conical_hull
@@ -719,6 +721,7 @@ function find_representative_periods(
         h in hull_indices
       ]) for p in 1:n_complete_periods
     ]
+    clustering_matrix = clustering_matrix[:, (i_rp + 1):end]
   else
     throw(ArgumentError("Clustering method is not supported"))
   end

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -803,7 +803,7 @@ function validate_initial_representatives(
   end
 
   # 2. Check that initial representatives do not contain a incomplete period
-  if aux_initial.last_period_duration ≠ aux_initial.period_duration
+  if aux_initial.last_period_duration ≠ aux_clustering.period_duration
     throw(
       ArgumentError(
         "Initial representatives have an incomplete last period, which is not allowed",

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -827,15 +827,15 @@ function validate_initial_representatives(
   end
 
   # 3. Check that the initial representatives and clustering data have the same keys
-  #TODO: see if this is the most efficient approach
-  key_columns_initial = select(initial_representatives, aux_clustering.key_columns)
-  key_columns_clustering = select(clustering_data, aux_clustering.key_columns)
-  keys_initial = Set(collect(eachrow(key_columns_initial)))
-  keys_clustering = Set(collect(eachrow(key_columns_clustering)))
-
-  if keys_initial ≠ keys_clustering
-    more_keys_initial = length(setdiff(keys_initial, keys_clustering))
-    more_keys_clustering = length(setdiff(keys_clustering, keys_initial))
+  more_keys_initial = size(
+    antijoin(initial_representatives, clustering_data; on = aux_clustering.key_columns),
+    1,
+  )
+  more_keys_clustering = size(
+    antijoin(clustering_data, initial_representatives; on = aux_clustering.key_columns),
+    1,
+  )
+  if more_keys_initial > 0 || more_keys_clustering > 0
     throw(
       ArgumentError(
         "Initial representatives and clustering data do not have the same keys\n" *

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -726,11 +726,6 @@ function find_representative_periods(
     throw(ArgumentError("Clustering method is not supported"))
   end
 
-  # Fill in the weight matrix using the assignments
-  for (p, rp) in enumerate(assignments)
-    weight_matrix[p, rp] = complete_period_weight
-  end
-
   # 5. Reinterpret the clustering results into a format we need
 
   # First, convert the matrix data back to dataframes using the previously saved key columns
@@ -766,6 +761,16 @@ function find_representative_periods(
         rp_matrix = hcat(rp_matrix, values)
       end
     end
+  end
+
+  assignments = [
+    argmin([
+      distance(clustering_matrix[:, p], rp_matrix[:, r]) for r in axes(rp_matrix, 2)
+    ]) for p in 1:n_complete_periods
+  ]
+
+  for (p, rp) in enumerate(assignments)
+    weight_matrix[p, rp] = complete_period_weight
   end
 
   # Next, re-append the last period if it was excluded from clustering

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -575,7 +575,10 @@ function find_representative_periods(
   end
 
   # 4. Do the clustering, now that the data is transformed into a matrix
-  if method ≡ :k_means
+  if n_rp == 0
+    rp_matrix = nothing
+    assignments = Int[]
+  elseif method ≡ :k_means
     # Do the clustering
     kmeans_result = kmeans(clustering_matrix, n_rp; distance, args...)
 
@@ -676,7 +679,11 @@ function find_representative_periods(
   # 5. Reinterpret the clustering results into a format we need
 
   # First, convert the matrix data back to dataframes using the previously saved key columns
-  rp_df = matrix_and_keys_to_df(rp_matrix, keys)
+  if isnothing(rp_matrix)
+    rp_df = DataFrame()
+  else
+    rp_df = matrix_and_keys_to_df(rp_matrix, keys)
+  end
 
   # In case of
   if !isempty(initial_representatives) && method ∈ [:k_means, :k_medoids]

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -572,7 +572,7 @@ function find_representative_periods(
 
   # 3. Build the clustering matrix
 
-  if method ∈ [:k_means, :k_medoids] && !isempty(initial_representatives)
+  if method in [:k_means, :k_medoids] && !isempty(initial_representatives)
     # If clustering is k-means or k-medoids we remove amount of initial representatives from n_rp
     n_rp -= i_rp
     clustering_matrix, keys = df_to_matrix_and_keys(
@@ -580,7 +580,7 @@ function find_representative_periods(
       aux.key_columns,
     )
 
-  elseif method ∈ [:convex_hull, :convex_hull_with_null, :conical_hull] &&
+  elseif method in [:convex_hull, :convex_hull_with_null, :conical_hull] &&
          !isempty(initial_representatives)
     # If clustering is one of the hull methods, we add initial representatives to the clustering matrix in front
     updated_clustering_data = deepcopy(clustering_data)
@@ -738,7 +738,7 @@ function find_representative_periods(
   end
 
   # In case of initial representatives and a non hull method, we add them now
-  if !isempty(initial_representatives) && method ∈ [:k_means, :k_medoids]
+  if !isempty(initial_representatives) && method in [:k_means, :k_medoids]
     representatives_to_add =
       select!(initial_representatives, :period => :rep_period, aux.key_columns..., :value)
     representatives_to_add.rep_period .= representatives_to_add.rep_period .+ n_rp

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -524,6 +524,7 @@ function find_representative_periods(
   # Find auxiliary data and pre-compute additional constants that are used multiple times alter
   aux = find_auxiliary_data(clustering_data)
   n_periods = aux.n_periods
+
   if n_rp > n_periods
     throw(
       ArgumentError(
@@ -582,8 +583,12 @@ function find_representative_periods(
   elseif method ∈ [:convex_hull, :convex_hull_with_null, :conical_hull] &&
          !isempty(initial_representatives)
     # If clustering is one of the hull methods, we add initial representatives to the clustering matrix in front
-    clustering_data.period = clustering_data.period .+ i_rp
-    clustering_data = vcat(initial_representatives, clustering_data)
+
+    # TODO: This should be done without a copy, changed to make it not in place
+    updated_clustering_data = deepcopy(clustering_data)
+    updated_clustering_data.period = updated_clustering_data.period .+ i_rp
+    clustering_data = vcat(initial_representatives, updated_clustering_data)
+
     clustering_matrix, keys = df_to_matrix_and_keys(
       clustering_data[
         clustering_data.period .≤ (n_complete_periods + maximum(
@@ -715,6 +720,7 @@ function find_representative_periods(
 
     # Reinterpret the results
     rp_matrix = clustering_matrix[:, hull_indices]
+
     assignments = [
       argmin([
         distance(clustering_matrix[:, h], clustering_matrix[:, p + i_rp]) for

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -11,6 +11,7 @@ export cluster!, dummy_cluster!, transform_wide_to_long!
         drop_incomplete_last_period::Bool = false,
         method::Symbol = :k_means,
         distance::SemiMetric = SqEuclidean(),
+        initial_representatives::AbstractDataFrame = DataFrame(),
         weight_type::Symbol = :convex,
         tol::Float64 = 1e-2,
         clustering_kwargs = Dict(),
@@ -50,6 +51,11 @@ finally `write_clustering_result_to_tables`.
   shorter representative period
 - `method` (default `:k_means``): clustering method to use, either `:k_means` and `:k_medoids`
 - `distance` (default `Distances.SqEuclidean()`): semimetric used to measure distance between data points.
+- `initial_representatives` initial representatives that should be
+    included in the clustering. The period column in the initial representatives
+    should be 1-indexed and the key columns should be the same as in the clustering data.
+    For the hull methods it will be added before clustering, for :k_means and :k_medoids
+    it will be added after clustering.
 - `weight_type` (default `:convex`): the type of weights to find; possible values are:
     - `:convex`: each period is represented as a convex sum of the
       representative periods (a sum with nonnegative weights adding into one)
@@ -73,6 +79,7 @@ function cluster!(
   drop_incomplete_last_period::Bool = false,
   method::Symbol = :k_means,
   distance::SemiMetric = SqEuclidean(),
+  initial_representatives::AbstractDataFrame = DataFrame(),
   weight_type::Symbol = :convex,
   tol::Float64 = 1e-2,
   clustering_kwargs = Dict(),
@@ -105,6 +112,7 @@ function cluster!(
     drop_incomplete_last_period,
     method,
     distance,
+    initial_representatives,
     clustering_kwargs...,
   )
   fit_rep_period_weights!(clusters; weight_type, tol, weight_fitting_kwargs...)

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -341,7 +341,7 @@ end
 
   @testset "Dataframe with different key columns passed for initial representatives" begin
     @test_throws ArgumentError(
-      "Initial representatives have different key columns than the clustering data",
+      "Key columns of initial represenatives do not match clustering data\nExpected was: [:timestep, :technology] \nFound was: [:timestep, :demand]",
     ) begin
       clustering_data = DataFrame([
         :period => repeat(1:2; inner = 4),
@@ -368,7 +368,9 @@ end
 
   @testset "Dataframe with different keys passed for initial representatives" begin
     @test_throws ArgumentError(
-      "Initial representatives have different keys than the clustering data",
+      "Initial representatives and clustering data do not have the same keys\n" *
+      "There are 0 extra keys in initial representatives\n" *
+      "and 2 extra keys in clustering data.",
     ) begin
       clustering_data = DataFrame([
         :period => repeat(1:2; inner = 6),

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -449,3 +449,133 @@ end
     end
   end
 end
+
+@testset "K-means and k-medoids with initial representatives" begin
+  @testset "K-means and complete periods" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1], 4),
+        :timestep => repeat(1:2; inner = 2, outer = 1),
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 1:4,
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :k_means,
+        initial_representatives = representatives,
+      )
+
+      clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+      [1.0, 2.0, 3.0, 4.0]
+    end
+  end
+
+  @testset "K-medoids and incomplete periods" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1], 4),
+        :timestep => repeat(1:2; inner = 2, outer = 1),
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 1:4,
+      ])
+
+      push!(clustering_data, [3, 1, "Solar", 6])
+      push!(clustering_data, [3, 1, "Nuclear", 6])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        3;
+        method = :k_medoids,
+        initial_representatives = representatives,
+      )
+
+      (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+        [1.0, 2.0, 3.0, 4.0]
+      ) && (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 3, :value] ==
+        [6.0, 6.0]
+      )
+    end
+  end
+
+  @testset "K-means and incomplete period" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1], 4),
+        :timestep => repeat(1:2; inner = 2, outer = 1),
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 1:4,
+      ])
+
+      push!(clustering_data, [3, 1, "Solar", 6])
+      push!(clustering_data, [3, 1, "Nuclear", 6])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        3;
+        method = :k_means,
+        initial_representatives = representatives,
+      )
+
+      (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+        [1.0, 2.0, 3.0, 4.0]
+      ) && (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 3, :value] ==
+        [6.0, 6.0]
+      )
+    end
+  end
+
+  @testset "K-medoids and complete period" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1], 4),
+        :timestep => repeat(1:2; inner = 2, outer = 1),
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 1:4,
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :k_medoids,
+        initial_representatives = representatives,
+      )
+
+      clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+      [1.0, 2.0, 3.0, 4.0]
+    end
+  end
+end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -314,3 +314,138 @@ end
     ) == (1,)
   end
 end
+
+@testset "Validating initial representatives" begin
+  @testset "DataFrame without periods passed for initial representatives" begin
+    initial_representatives = DataFrame([:timestep => 1:2, :value => 1:2])
+    @test_throws DomainError(
+      initial_representatives,
+      "DataFrame must contain column `period`; call split_into_periods! to split it into periods.",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        false,
+        1,
+      )
+    end
+  end
+
+  @testset "Dataframe with different key columns passed for initial representatives" begin
+    @test_throws ArgumentError(
+      "Initial representatives have different key columns than the clustering data",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      initial_representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :demand => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        false,
+        1,
+      )
+    end
+  end
+
+  @testset "Dataframe with different keys passed for initial representatives" begin
+    @test_throws ArgumentError(
+      "Initial representatives have different keys than the clustering data",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 6),
+        :timestep => repeat(1:3; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 6),
+        :value => 5:16,
+      ])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      initial_representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        false,
+        1,
+      )
+    end
+  end
+
+  @testset "Initial representatives more than n_rp" begin
+    @test_throws ArgumentError(
+      "The number of representative periods is 1 but has to be at least 2.",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      initial_representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        false,
+        1,
+      )
+    end
+  end
+
+  @testset "Initial representatives more than n_rp" begin
+    @test_throws ArgumentError(
+      "The number of representative periods is 2 but has to be at least 3.",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      push!(clustering_data, [3, 1, "Solar", 6])
+      push!(clustering_data, [3, 1, "Nuclear", 6])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      initial_representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        true,
+        2,
+      )
+    end
+  end
+end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -317,12 +317,14 @@ end
 
 @testset "Validating initial representatives" begin
   @testset "DataFrame without periods passed for initial representatives" begin
-    initial_representatives = DataFrame([:timestep => 1:2, :value => 1:2])
+    initial_representatives =
+      DataFrame([:year => repeat([2030], 2), :timestep => 1:2, :value => 1:2])
     @test_throws DomainError(
       initial_representatives,
       "DataFrame must contain column `period`; call split_into_periods! to split it into periods.",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -341,9 +343,10 @@ end
 
   @testset "Dataframe with different key columns passed for initial representatives" begin
     @test_throws ArgumentError(
-      "Key columns of initial represenatives do not match clustering data\nExpected was: [:timestep, :technology] \nFound was: [:timestep, :demand]",
+      "Key columns of initial represenatives do not match clustering data\nExpected was: [:year, :timestep, :technology] \nFound was: [:year, :timestep, :demand]",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -351,6 +354,7 @@ end
       ])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :demand => repeat(["Solar", "Nuclear"], 4),
@@ -371,6 +375,7 @@ end
       "Initial representatives have an incomplete last period, which is not allowed",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:2; inner = 6),
         :timestep => repeat(1:3; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -378,6 +383,7 @@ end
       ])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => [1, 1, 1, 1],
         :timestep => [1, 1, 2, 2],
         :technology => repeat(["Solar", "Nuclear"], 2),
@@ -400,6 +406,7 @@ end
       "and 6 extra keys in clustering data.",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:2; inner = 6),
         :timestep => repeat(1:3; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -407,6 +414,7 @@ end
       ])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
+        :year => repeat([2030], 6),
         :period => repeat(1:2; inner = 3),
         :timestep => repeat(1:3; outer = 2),
         :technology => repeat(["Solar"], 6),
@@ -427,6 +435,7 @@ end
       "The number of representative periods is 1 but has to be at least 2.",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -434,6 +443,7 @@ end
       ])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -454,15 +464,17 @@ end
       "The number of representative periods is 2 but has to be at least 3.",
     ) begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
         :value => 5:12,
       ])
-      push!(clustering_data, [3, 1, "Solar", 6])
-      push!(clustering_data, [3, 1, "Nuclear", 6])
+      push!(clustering_data, [2030, 3, 1, "Solar", 6])
+      push!(clustering_data, [2030, 3, 1, "Nuclear", 6])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -483,6 +495,7 @@ end
   @testset "K-means and complete periods" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -490,6 +503,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Solar", "Nuclear"], 2),
@@ -511,6 +525,7 @@ end
   @testset "K-medoids and incomplete periods" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -518,14 +533,15 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Solar", "Nuclear"], 2),
         :value => 1:4,
       ])
 
-      push!(clustering_data, [3, 1, "Solar", 6])
-      push!(clustering_data, [3, 1, "Nuclear", 6])
+      push!(clustering_data, [2030, 3, 1, "Solar", 6])
+      push!(clustering_data, [2030, 3, 1, "Nuclear", 6])
 
       clustering_result = find_representative_periods(
         clustering_data,
@@ -547,6 +563,7 @@ end
   @testset "K-means and incomplete period" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -554,14 +571,15 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Solar", "Nuclear"], 2),
         :value => 1:4,
       ])
 
-      push!(clustering_data, [3, 1, "Solar", 6])
-      push!(clustering_data, [3, 1, "Nuclear", 6])
+      push!(clustering_data, [2030, 3, 1, "Solar", 6])
+      push!(clustering_data, [2030, 3, 1, "Nuclear", 6])
 
       clustering_result = find_representative_periods(
         clustering_data,
@@ -583,6 +601,7 @@ end
   @testset "K-medoids and complete period" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -590,6 +609,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Solar", "Nuclear"], 2),
@@ -611,6 +631,7 @@ end
   @testset "rp_matrix also contains initial representatives and at the right place in the right order" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -618,6 +639,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Nuclear", "Solar"], 2),
@@ -638,6 +660,7 @@ end
   @testset "Initial representatives already all representatives" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -645,6 +668,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1], 4),
         :timestep => repeat(1:2; inner = 2, outer = 1),
         :technology => repeat(["Solar", "Nuclear"], 2),
@@ -668,6 +692,7 @@ end
   @testset "Initial representatives already all representatives convex hull" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -675,6 +700,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Nuclear", "Solar"], 4),
@@ -701,6 +727,7 @@ end
   @testset "Initial representatives already all representatives convex hull with null" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -708,6 +735,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Nuclear", "Solar"], 4),
@@ -734,6 +762,7 @@ end
   @testset "Initial representatives already all representatives conical hull" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -741,6 +770,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Nuclear", "Solar"], 4),
@@ -767,6 +797,7 @@ end
   @testset "Convex hull with one initial representative picks correct initial and second representative" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:3; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 3),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -774,6 +805,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1]; inner = 4),
         :timestep => repeat(1:2; inner = 2),
         :technology => repeat(["Nuclear", "Solar"], 2),
@@ -802,6 +834,7 @@ end
   @testset "Convex hull with null with one initial representative picks correct initial and second representative" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:3; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 3),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -809,6 +842,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1]; inner = 4),
         :timestep => repeat(1:2; inner = 2),
         :technology => repeat(["Nuclear", "Solar"], 2),
@@ -830,6 +864,7 @@ end
   @testset "Conical hull with one initial representative picks correct initial and second representative" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:3; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 3),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -837,6 +872,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1]; inner = 4),
         :timestep => repeat(1:2; inner = 2),
         :technology => repeat(["Nuclear", "Solar"], 2),
@@ -858,6 +894,7 @@ end
   @testset "Convex hull does not contain intial representative in clustering matrix" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 12),
         :period => repeat(1:3; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 3),
         :technology => repeat(["Solar", "Nuclear"], 6),
@@ -865,6 +902,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 4),
         :period => repeat([1]; inner = 4),
         :timestep => repeat(1:2; inner = 2),
         :technology => repeat(["Nuclear", "Solar"], 2),
@@ -886,6 +924,7 @@ end
   @testset "Weights are equal for each method when representatives don't need to be found" begin
     @test begin
       clustering_data = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Solar", "Nuclear"], 4),
@@ -893,6 +932,7 @@ end
       ])
 
       representatives = DataFrame([
+        :year => repeat([2030], 8),
         :period => repeat(1:2; inner = 4),
         :timestep => repeat(1:2; inner = 2, outer = 2),
         :technology => repeat(["Nuclear", "Solar"], 4),

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -578,4 +578,33 @@ end
       [1.0, 2.0, 3.0, 4.0]
     end
   end
+
+  @testset "Initial representatives already all representatives" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1], 4),
+        :timestep => repeat(1:2; inner = 2, outer = 1),
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 1:4,
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        1;
+        method = :k_medoids,
+        initial_representatives = representatives,
+      )
+
+      println(clustering_result.profiles)
+      clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+      [1.0, 2.0, 3.0, 4.0]
+    end
+  end
 end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -853,3 +853,42 @@ end
     end
   end
 end
+@testset "Weights are correctly calculated with representatives" begin
+  @testset "Weights are equal for each method when representatives don't need to be found" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Nuclear", "Solar"], 4),
+        :value => [2, 1, 4, 3, 14, 13, 16, 15],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull,
+        initial_representatives = representatives,
+        distance = CosineDist(),
+      )
+
+      clustering_result_2 = find_representative_periods(
+        clustering_data,
+        2;
+        method = :k_medoids,
+        initial_representatives = representatives,
+        distance = CosineDist(),
+      )
+
+      weight_matrix_1 = clustering_result.weight_matrix
+      weight_matrix_2 = clustering_result_2.weight_matrix
+      weight_matrix_1 == weight_matrix_2
+    end
+  end
+end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -370,7 +370,7 @@ end
     @test_throws ArgumentError(
       "Initial representatives and clustering data do not have the same keys\n" *
       "There are 0 extra keys in initial representatives\n" *
-      "and 2 extra keys in clustering data.",
+      "and 4 extra keys in clustering data.",
     ) begin
       clustering_data = DataFrame([
         :period => repeat(1:2; inner = 6),

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -366,11 +366,9 @@ end
     end
   end
 
-  @testset "Dataframe with different keys passed for initial representatives" begin
+  @testset "Initial representatives with incomplete period" begin
     @test_throws ArgumentError(
-      "Initial representatives and clustering data do not have the same keys\n" *
-      "There are 0 extra keys in initial representatives\n" *
-      "and 4 extra keys in clustering data.",
+      "Initial representatives have an incomplete last period, which is not allowed",
     ) begin
       clustering_data = DataFrame([
         :period => repeat(1:2; inner = 6),
@@ -380,10 +378,39 @@ end
       ])
       aux_clustering = find_auxiliary_data(clustering_data)
       initial_representatives = DataFrame([
-        :period => repeat(1:2; inner = 4),
-        :timestep => repeat(1:2; inner = 2, outer = 2),
-        :technology => repeat(["Solar", "Nuclear"], 4),
-        :value => 5:12,
+        :period => [1, 1, 1, 1],
+        :timestep => [1, 1, 2, 2],
+        :technology => repeat(["Solar", "Nuclear"], 2),
+        :value => 5:8,
+      ])
+      validate_initial_representatives(
+        initial_representatives,
+        clustering_data,
+        aux_clustering,
+        false,
+        1,
+      )
+    end
+  end
+
+  @testset "Dataframe with different keys passed for initial representatives" begin
+    @test_throws ArgumentError(
+      "Initial representatives and clustering data do not have the same keys\n" *
+      "There are 0 extra keys in initial representatives\n" *
+      "and 6 extra keys in clustering data.",
+    ) begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 6),
+        :timestep => repeat(1:3; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 6),
+        :value => 5:16,
+      ])
+      aux_clustering = find_auxiliary_data(clustering_data)
+      initial_representatives = DataFrame([
+        :period => repeat(1:2; inner = 3),
+        :timestep => repeat(1:3; outer = 2),
+        :technology => repeat(["Solar"], 6),
+        :value => 5:10,
       ])
       validate_initial_representatives(
         initial_representatives,

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -602,9 +602,200 @@ end
         initial_representatives = representatives,
       )
 
-      println(clustering_result.profiles)
       clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
       [1.0, 2.0, 3.0, 4.0]
+    end
+  end
+end
+
+@testset "Hulls with initial representatives" begin
+  @testset "Initial representatives already all representatives convex hull" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Nuclear", "Solar"], 4),
+        :value => [2, 1, 4, 3, 14, 13, 16, 15],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull,
+        initial_representatives = representatives,
+      )
+
+      (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+        [2.0, 1.0, 4.0, 3.0]
+      ) && (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+        [14.0, 13.0, 16.0, 15.0]
+      )
+    end
+  end
+
+  @testset "Initial representatives already all representatives convex hull with null" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Nuclear", "Solar"], 4),
+        :value => [2, 1, 4, 3, 14, 13, 16, 15],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull_with_null,
+        initial_representatives = representatives,
+      )
+
+      (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+        [2.0, 1.0, 4.0, 3.0]
+      ) && (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+        [14.0, 13.0, 16.0, 15.0]
+      )
+    end
+  end
+
+  @testset "Initial representatives already all representatives conical hull" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Solar", "Nuclear"], 4),
+        :value => 5:12,
+      ])
+
+      representatives = DataFrame([
+        :period => repeat(1:2; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 2),
+        :technology => repeat(["Nuclear", "Solar"], 4),
+        :value => [2, 1, 4, 3, 14, 13, 16, 15],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :conical_hull,
+        initial_representatives = representatives,
+      )
+
+      (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+        [2.0, 1.0, 4.0, 3.0]
+      ) && (
+        clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+        [14.0, 13.0, 16.0, 15.0]
+      )
+    end
+  end
+
+  @testset "Convex hull with one initial representative" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:3; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 3),
+        :technology => repeat(["Solar", "Nuclear"], 6),
+        :value => repeat(1:2:12; inner = 2),
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1]; inner = 4),
+        :timestep => repeat(1:2; inner = 2),
+        :technology => repeat(["Nuclear", "Solar"], 2),
+        :value => [11, 11, 13, 13],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull,
+        initial_representatives = representatives,
+      )
+
+      (
+          clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+          [11.0, 11.0, 13.0, 13.0]
+        ) &&
+        (
+          clustering_result.profiles[clustering_result.profiles.rep_period .== 2, :value] ==
+          [1.0, 1.0, 3.0, 3.0]
+        ) &&
+        (clustering_result.weight_matrix == [0.0 1.0; 0.0 1.0; 1.0 0.0])
+    end
+  end
+
+  @testset "Convex hull with null with one initial representative" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:3; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 3),
+        :technology => repeat(["Solar", "Nuclear"], 6),
+        :value => repeat(1:2:12; inner = 2),
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1]; inner = 4),
+        :timestep => repeat(1:2; inner = 2),
+        :technology => repeat(["Nuclear", "Solar"], 2),
+        :value => [11, 11, 13, 13],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull_with_null,
+        initial_representatives = representatives,
+      )
+
+      clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+      [11.0, 11.0, 13.0, 13.0]
+    end
+  end
+
+  @testset "Conical hull with one initial representative" begin
+    @test begin
+      clustering_data = DataFrame([
+        :period => repeat(1:3; inner = 4),
+        :timestep => repeat(1:2; inner = 2, outer = 3),
+        :technology => repeat(["Solar", "Nuclear"], 6),
+        :value => repeat(1:2:12; inner = 2),
+      ])
+
+      representatives = DataFrame([
+        :period => repeat([1]; inner = 4),
+        :timestep => repeat(1:2; inner = 2),
+        :technology => repeat(["Nuclear", "Solar"], 2),
+        :value => [11, 11, 13, 13],
+      ])
+
+      clustering_result = find_representative_periods(
+        clustering_data,
+        2;
+        method = :convex_hull_with_null,
+        initial_representatives = representatives,
+      )
+
+      clustering_result.profiles[clustering_result.profiles.rep_period .== 1, :value] ==
+      [11.0, 11.0, 13.0, 13.0]
     end
   end
 end


### PR DESCRIPTION
Closes #84 

An optional argument `initial_representatives` is added to the method `find_representative_periods()`, those initial representatives will be included in the final set of representatives. An extra validation function is used to check whether this set of initial representatives can be used for the clustering data. Based on the method chosen (hull method or k-means/k-medoids) the representatives are either added beforehand or afterwards. Weights are refitted to the closest representative, so there is an option that weight 0 is assigned to some of the initial representatives. 

@greg-neustroev Regarding the lint workflow, I am correctly running the linter, but it seems that symbols like ∈ are still accepted. Should I manually change those to `in`?

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
