### PR TITLE
Fix formatting in .lychee.toml

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,7 +3,8 @@ exclude = [
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
   "^https://TulipaEnergy.github.io/TulipaClustering.jl/stable$",
-  "zenodo.org/badge/DOI/FIXME$"
+  "zenodo.org/badge/DOI/FIXME$",
+  "https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593",  
 ]
 
 exclude_path = [


### PR DESCRIPTION
Adding `"https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593"` to the `exclude` array in `.lychee.toml` to prevent link checking for this URL.

## Related issues

There is no related issue.

## Checklist


- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
