### PR TITLE
Add validation for drop incomplete period

### DIFF
--- a/src/find-representative-periods.jl
+++ b/src/find-representative-periods.jl
@@ -110,6 +110,14 @@ function find_representative_periods(
     )
   end
 
+  if drop_incomplete_last_period && n_rp > n_periods - 1
+    throw(
+      ArgumentError(
+        "The number of representative periods exceeds the total number of complete periods when dropping the last incomplete period, $n_rp > $(n_periods - 1).",
+      ),
+    )
+  end
+
   has_incomplete_last_period = aux.last_period_duration ≠ aux.period_duration
   is_last_period_excluded = has_incomplete_last_period && !drop_incomplete_last_period
   n_complete_periods = has_incomplete_last_period ? n_periods - 1 : n_periods

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -460,7 +460,7 @@ end
 end
 
 @testset "Bad number of representative periods" begin
-  @testset "Test that non-positive numbers of RPs throw correctly" begin
+  @testset "Test that a wrong numbers of RPs throw correctly" begin
     clustering_data = DataFrame([
       :period => repeat(1:2; inner = 4),
       :timestep => repeat(1:2; inner = 2, outer = 2),
@@ -470,6 +470,29 @@ end
     @test_throws ArgumentError find_representative_periods(clustering_data, 0)
     @test_throws ArgumentError find_representative_periods(clustering_data, -1)
     @test_throws ArgumentError find_representative_periods(clustering_data, 3)
+  end
+  @testset "Test that a wrong numbers of RPs with incomplete periods throw correctly" begin
+    clustering_data = DataFrame([
+      :period => repeat(1:2; inner = 4),
+      :timestep => repeat(1:2; inner = 2, outer = 2),
+      :technology => repeat(["Solar", "Nuclear"], 4),
+      :value => 5:12,
+    ])
+    # add a row with an incomplete period for all the technologies
+    clustering_data = vcat(
+      clustering_data,
+      DataFrame([
+        :period => repeat([3], 2),
+        :timestep => [1, 1],
+        :technology => ["Solar", "Nuclear"],
+        :value => [13, 14],
+      ]),
+    )
+    @test_throws ArgumentError find_representative_periods(
+      clustering_data,
+      3;
+      drop_incomplete_last_period = true,
+    )
   end
 end
 


### PR DESCRIPTION
This pull request improves error handling in the `find_representative_periods` function and enhances its corresponding tests to ensure that invalid input scenarios are properly detected and reported. The main focus is on cases where the number of requested representative periods is not valid, especially when dealing with incomplete periods.

**Error handling improvements:**

* Added a check in `find_representative_periods` to throw an `ArgumentError` if the number of representative periods exceeds the number of complete periods when `drop_incomplete_last_period` is enabled, with a clear error message.

**Testing enhancements:**

* Updated test descriptions to clarify that both non-positive and excessive numbers of representative periods are tested for correct error throwing.
* Added a new test case to verify that an `ArgumentError` is thrown when requesting too many representative periods while dropping an incomplete last period, using a dataset with an incomplete period.

## Related issues

Closes #122 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
