### PR TITLE
Add initial representatives per group in the cluster function 

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -95,6 +95,7 @@ function cluster!(
     input_database_schema,
     table_names = Dict("profiles" => input_profile_table_name),
     layout,
+    initial_representatives,
   )
   _check_layout_consistency_with_cols_to_groupby(layout)
 


### PR DESCRIPTION
Adding initial representative periods to the cluster function for each group in the clustering process. It also introduces validation to ensure the initial representatives DataFrame has the necessary columns and includes tests for these new features.

### New feature: Initial representatives support in clustering

* The `cluster!` function now accepts an `initial_representatives` DataFrame argument, which is filtered by group and passed to the clustering logic for each group. This enables users to specify custom starting points for representative periods per group. [[1]](diffhunk://#diff-b13d51dd7f10870f30cc1e6edd087c15ed8c45bc987364d21b2dad1b400a59b6R98) [[2]](diffhunk://#diff-b13d51dd7f10870f30cc1e6edd087c15ed8c45bc987364d21b2dad1b400a59b6R121-R124)
* Added the `_get_initial_representatives_for_group` helper function to filter the provided initial representatives to match each group's key columns, ensuring correct representatives are used for each group.

### Data validation improvements

* The `validate_data!` and `_validate_required_tables_and_columns!` functions now accept and validate the `initial_representatives` argument, checking that it contains all required columns (matching the profiles table plus the `period` column). [[1]](diffhunk://#diff-d7d8c58ab1e38469775c325990968cd2a7a2370c6677987fccff29602820fc05R28) [[2]](diffhunk://#diff-d7d8c58ab1e38469775c325990968cd2a7a2370c6677987fccff29602820fc05L36-R43) [[3]](diffhunk://#diff-d7d8c58ab1e38469775c325990968cd2a7a2370c6677987fccff29602820fc05R62) [[4]](diffhunk://#diff-d7d8c58ab1e38469775c325990968cd2a7a2370c6677987fccff29602820fc05R96) [[5]](diffhunk://#diff-d7d8c58ab1e38469775c325990968cd2a7a2370c6677987fccff29602820fc05R107-R119)

### Testing enhancements

* Added extensive tests to `test/test-convenience.jl` to verify correct handling of initial representatives across different grouping configurations, including cases with full, partial, and no grouping columns. The tests check that clustering results incorporate the initial representatives as expected.
* Added tests to `test/test-data-validation.jl` to ensure appropriate exceptions and error messages are raised when required columns are missing from the initial representatives DataFrame. [[1]](diffhunk://#diff-6ceca7cc67b2e7c85aa6bc13bd6a4067dff9565427031d9848355e4b37b34674R34) [[2]](diffhunk://#diff-6ceca7cc67b2e7c85aa6bc13bd6a4067dff9565427031d9848355e4b37b34674R51-R95)

## Related issues

Closes #121 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
