### PR TITLE
Improve convex hull projection caching

### DIFF
--- a/docs/src/20-concepts.md
+++ b/docs/src/20-concepts.md
@@ -73,6 +73,23 @@ The following figure shows the projection errors when approximating base period 
 
 The `distance` parameter in the function [`cluster!`](@ref) defines the metric used to measure how different the datapoints are. The parameter recieves any metric from the package [Distances.jl](https://github.com/JuliaStats/Distances.jl). By default it uses, euclidean distance, meaning that we seek the closest point in the convex hull by calculating the absolute distance. For instance, in the following figure, both points (2,3) and (3,6) is possible to find weights so that its error is smaller when projected to the hull.
 
+### Convex hull projection cache
+
+The hull-selection methods cache each candidate period's projection onto the current
+hull by default. When a new representative is added, a cached projection is reused
+only when the Euclidean obtuse-angle certificate
+
+$$
+(d - q)^\mathsf{T}(c - q) \le 0
+$$
+
+holds, where $d$ is the candidate period, $q$ is its cached projection, and $c$ is
+the newly added representative. This proves that the cached projection remains valid
+for the enlarged hull. The cache is therefore an exact reuse optimization rather than
+an approximate distance-ranking heuristic. Pass `cache = false` to recompute every
+projection. The certificate is used only with `Euclidean` and `SqEuclidean` distances;
+other metrics recompute projections even when caching is enabled.
+
 ![Euclidian Distance](assets/euclidian-distance.png)
 
 Nevertheless, when using the hull clustering, we want to measure dissimilarity so that:

--- a/src/cluster.jl
+++ b/src/cluster.jl
@@ -614,7 +614,7 @@ function append_period_from_source_df_as_rp!(
 end
 
 """
-    greedy_convex_hull(matrix; n_points, distance, initial_indices, mean_vector)
+    greedy_convex_hull(matrix; n_points, distance, initial_indices, mean_vector, cache)
 
   Greedy method for finding `n_points` points in a hull of the dataset. The points
   are added iteratively, at each step the point that is the furthest away from the
@@ -628,6 +628,17 @@ end
       it will be chosen as the point furthest away from the `mean_vector`; this can be
       nothing, in which case the first step will add a point furtherst away from
       the centroid (the mean) of the dataset
+    - `cache`: whether to cache each candidate's projection onto the current hull;
+            cached projections are reused only for `Euclidean` and `SqEuclidean` distances
+            when the obtuse-angle certificate proves that the projection remains valid after
+            a new hull point is added. Other distance types recompute projections.
+            Set to `false` to recompute every candidate projection.
+
+The projection cache stores both the projected point and its distance. For a cached
+candidate `d` and the newly added hull point `c`, the cached projection `q` is reused
+when `(d - q)' * (c - q) ≤ 0`. This certificate guarantees that `q` remains the
+closest point in the enlarged convex hull for Euclidean geometry. Cache reuse changes
+the amount of projection work, but not the result relative to the uncached path.
 """
 function greedy_convex_hull(
     matrix::AbstractMatrix{Float64};
@@ -635,6 +646,7 @@ function greedy_convex_hull(
     distance::SemiMetric,
     initial_indices::Union{Vector{Int}, Nothing} = nothing,
     mean_vector::Union{Vector{Float64}, Nothing} = nothing,
+    cache::Bool = true,
     kwargs...,
 )
     # First resolve the points that are already in the hull given via `initial_indices`
@@ -652,12 +664,9 @@ function greedy_convex_hull(
         return initial_indices[1:n_points]
     end
 
-    # Check if the keyword argument `heuristic_distance` is passed
-    heuristic_distance = get(kwargs, :heuristic_distance, true)
-
     # Start filling in the remaining points
     hull_indices = initial_indices
-    distances_cache = fill(Inf, size(matrix, 2))  # store previously computed distances
+    projection_cache = Dict{Int, Tuple{Vector{Float64}, Float64}}()
     starting_index = length(initial_indices) + 1
 
     # unpack kwargs
@@ -677,30 +686,12 @@ function greedy_convex_hull(
             last_added_vector = view(matrix, :, last(hull_indices))
             target_vector = view(matrix, :, column_index)
 
-            # Check whether the distance was previosly computed
-            cached_distance = distances_cache[column_index]
-            # Check whether the cached_distance is already too small for the vector to be selected
-            if cached_distance <= max_distance
-                continue
-            end
-            if heuristic_distance
-                d_temp = distance(target_vector, last_added_vector)
-                if d_temp ≥ cached_distance
-                    d_min = cached_distance
-                else
-                    subgradient = x -> hull_matrix' * (hull_matrix * x - target_vector)
-                    x = projection_matrix * target_vector
-                    x = projected_subgradient_descent!(
-                        x;
-                        subgradient,
-                        projection = project_onto_simplex,
-                        filtered_kwargs...,
-                    )
-                    projected_target = hull_matrix * x
-                    d = distance(projected_target, target_vector)
-                    d_min = min(d, d_temp)
-                    distances_cache[column_index] = d_min
-                end
+            cached = get(projection_cache, column_index, nothing)
+            if cache &&
+               (distance isa Euclidean || distance isa SqEuclidean) &&
+               cached !== nothing &&
+               dot(target_vector - cached[1], last_added_vector - cached[1]) ≤ 0
+                d = cached[2]
             else
                 subgradient = x -> hull_matrix' * (hull_matrix * x - target_vector)
                 x = projection_matrix * target_vector
@@ -712,12 +703,11 @@ function greedy_convex_hull(
                 )
                 projected_target = hull_matrix * x
                 d = distance(projected_target, target_vector)
-                d_min = min(d, cached_distance)
-                distances_cache[column_index] = d_min
+                projection_cache[column_index] = (projected_target, d)
             end
 
-            if d_min > max_distance
-                max_distance = d_min
+            if d > max_distance
+                max_distance = d
                 furthest_vector_index = column_index
             end
         end

--- a/test/test-cluster.jl
+++ b/test/test-cluster.jl
@@ -446,7 +446,7 @@ end
             clustering_result.weight_matrix == [1.0 0.0; 0.0 1.0]
         end
     end
-    @testset "Make sure that convex hull clustering finds the hull when selecting heuristic_distance = false" begin
+    @testset "Make sure that convex hull clustering finds the hull when caching is disabled" begin
         @test begin
             clustering_data = DataFrame([
                 :period => repeat(1:2; inner = 4),
@@ -458,7 +458,7 @@ end
                 clustering_data,
                 2;
                 method = :convex_hull,
-                heuristic_distance = false,
+                cache = false,
             )
             clustering_result.weight_matrix == [1.0 0.0; 0.0 1.0]
         end
@@ -609,6 +609,25 @@ end
             ),
         ) == (1,)
     end
+end
+
+@testset "Greedy convex hull cache" begin
+    matrix = [
+        0.0 1.0 0.0 0.3
+        0.0 0.0 1.0 0.3
+    ]
+
+    @test TulipaClustering.greedy_convex_hull(
+        matrix;
+        n_points = 3,
+        distance = Euclidean(),
+        cache = true,
+    ) == TulipaClustering.greedy_convex_hull(
+        matrix;
+        n_points = 3,
+        distance = Euclidean(),
+        cache = false,
+    )
 end
 
 @testset "Validating initial representatives" begin
@@ -1179,7 +1198,7 @@ end
         end
     end
 
-    @testset "Convex hull with one initial representative picks correct initial and second representative when heuristic_distance = false" begin
+    @testset "Convex hull with one initial representative picks correct initial and second representative when caching is disabled" begin
         @test begin
             clustering_data = DataFrame([
                 :period => repeat(1:3; inner = 4),
@@ -1200,7 +1219,7 @@ end
                 2;
                 method = :convex_hull,
                 initial_representatives = representatives,
-                heuristic_distance = false,
+                cache = false,
             )
 
             (
@@ -1249,7 +1268,7 @@ end
         end
     end
 
-    @testset "Convex hull with null with one initial representative picks correct initial and second representative when heuristic_distance = false" begin
+    @testset "Convex hull with null with one initial representative picks correct initial and second representative when caching is disabled" begin
         @test begin
             clustering_data = DataFrame([
                 :period => repeat(1:3; inner = 4),
@@ -1270,7 +1289,7 @@ end
                 2;
                 method = :convex_hull_with_null,
                 initial_representatives = representatives,
-                heuristic_distance = false,
+                cache = false,
             )
 
             clustering_result.profiles[
@@ -1310,7 +1329,7 @@ end
         end
     end
 
-    @testset "Conical hull with one initial representative picks correct initial and second representative when heuristic_distance = false" begin
+    @testset "Conical hull with one initial representative picks correct initial and second representative when caching is disabled" begin
         @test begin
             clustering_data = DataFrame([
                 :period => repeat(1:3; inner = 4),
@@ -1331,7 +1350,7 @@ end
                 2;
                 method = :convex_hull_with_null,
                 initial_representatives = representatives,
-                heuristic_distance = false,
+                cache = false,
             )
 
             clustering_result.profiles[


### PR DESCRIPTION
Replaces the heuristic distance cache in `greedy_convex_hull` with a certified projection cache.

**Changes**

- Adds an explicit `cache::Bool` option.
- Caches each candidate’s projection and distance.
- Reuses cached projections only when the Euclidean obtuse-angle certificate is satisfied.
- Recomputes projections for non-Euclidean distance metrics.
- Removes the `heuristic_distance` option.
- Updates hull tests to cover cached and uncached behavior.
- Documents the cache algorithm and certificate in `cluster.jl` and `20-concepts.md`.

**Testing**

- Direct cached versus uncached check passes with identical selections: `[2, 3, 1]`.
- Static diagnostics report no errors.
- Full package test execution reached the test phase but exceeded the execution timeout.

## Related issues

Closes #172 

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaClustering.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
